### PR TITLE
suggest slots

### DIFF
--- a/app/controllers/planner_controller.rb
+++ b/app/controllers/planner_controller.rb
@@ -5,5 +5,35 @@ class PlannerController < ApplicationController
 
     def show
         @course = Course.find(params[:id])
+
+        # get this week's slots
+        this_week = @course.schedules.where(year: Date.current.year, week: Date.current.cweek).first
+        this_week = this_week.slots.select{|k,v| k >= Date.current.wday}
+
+        # get next week's slots
+        next_week = @course.schedules.where(year: (Date.current + 7).year, week: (Date.current + 7).cweek).first
+
+        @suggestions = []
+
+        if !this_week.empty? then
+            # if there are still days left this week, suggest 4 slots on the first day
+            day = this_week.keys.first
+            @suggestions += helpers.slots_to_suggestions(@course, Date.current.year, Date.current.cweek, day, this_week[day], 4)
+
+            # fill the remaining slots with the next available day
+            remaining = @suggestions.count > 1 ? 2 : 4
+
+            if this_week.keys.count >= 2 then
+                day = this_week.keys[1]
+                @suggestions += helpers.slots_to_suggestions(@course, Date.current.year, Date.current.cweek, day, this_week[day], remaining)
+            else
+                day = next_week.keys.first
+                @suggestions += helpers.slots_to_suggestions(@course, (Date.current + 7).year, (Date.current + 7).cweek, day, next_week[day], remaining)
+            end
+        else
+            # if there are no more slots available this week, suggest 4 slots on the first available day next week
+            day = next_week.keys.first
+            @suggestions += helpers.slots_to_suggestions(@course, (Date.current + 7).year, (Date.current + 7).cweek, day, next_week[day], 6)
+        end
     end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,2 +1,0 @@
-module ApplicationHelper
-end

--- a/app/helpers/planner_helper.rb
+++ b/app/helpers/planner_helper.rb
@@ -1,0 +1,137 @@
+module PlannerHelper
+    SLOTS_PER_HOUR = 4
+    DAYS = ["Zondag", "Maandag", "Dinsdag", "Woensdag", "Donderdag", "Vrijdag", "Zaterdag"]
+    MONTHS = ["n/a", "januari", "februari", "maart", "april", "mei", "juni", 
+              "juli", "augustus", "september", "oktober", "november", "december"]
+
+    def get_options(course, year, week, day, slots)
+        options = []
+        today = year == Date.current.year && week == Date.current.cweek && day == Date.current.wday
+        now = DateTime.now
+
+        # run through the available hours
+        slots.keys.each do |hour|
+            # run through the available slots within the hour
+            for i in 1..SLOTS_PER_HOUR do
+                # skip if the slot is less than 1 hour away
+                if today && (hour <= now.hour || (hour == now.hour + 1 && now.min > (i-1) * 60 / SLOTS_PER_HOUR)) then
+                    next
+                end
+
+                # find the appointments in this slot
+                taken = course.appointments.where(year: year, week: week, day: day, hour: hour, slot: i).count
+
+                # skip if all available places are already filled
+                if taken < slots[hour] then
+                    options.push([hour, i])
+                end 
+            end
+        end
+
+        return options
+    end
+
+    def slots_to_suggestions(course, year, week, day, slots, amount)
+        all_selected = []
+        result = []
+        options = get_options(course, year, week, day, slots)
+        srand(current_user.id || 9393927)
+
+        # skip if there are no options
+        if options.count < 1 then
+            return []
+        end
+
+        # if we need 2 suggestions or less, always get random options (must be at least 1,5 hour apart)
+        if amount <= 2 then
+            # get a random option
+            selected = options.sample
+            all_selected.push(selected)
+            result.push(hour_slot_to_result(course, year, week, day, selected))
+            
+            # loop until we have all required options
+            counter = 0
+            until result.count == amount || counter == 100
+                counter += 1
+
+                # get another random option
+                selected = options.sample
+
+                # get time diff
+                hdiff = (selected[0] - result[0]["hour"]).abs
+                sdiff = (selected[1] - result[0]["slot"]).abs
+
+                # check if it is at least 1,5 hour from the first selected option
+                if (hdiff == 1 && sdiff > 2) || hdiff > 1 then
+                    all_selected.push(selected)
+                    result.push(hour_slot_to_result(course, year, week, day, selected))
+                end
+            end
+        # if we need more than 2 options, always get the first, then 50% in the first half and 25% in the third and fourth quarter
+        else
+            # get the first
+            result.push(hour_slot_to_result(course, year, week, day, options.first))
+            all_selected.push(options.first)
+
+            # run through until we have all the required options
+            counter = 0
+            until result.count == amount || counter == 100
+                counter += 1
+
+                # get a random option
+                selected = select_candidates(amount, all_selected.count, options).sample
+
+                # check that it is not already selected
+                if !all_selected.include? selected then
+                    all_selected.push(selected)
+                    result.push(hour_slot_to_result(course, year, week, day, selected))
+                end
+            end
+        end
+
+        return result.sort_by{|i| i["dt"]}
+    end
+
+    def select_candidates(amount, count, options)
+        # make sure we're looking for options in the right segment of the day
+        complete = count.to_f / amount.to_f
+
+        if complete < 0.5 then
+            return options.slice(0, (options.count / 2) - 1)
+        end
+
+        if complete < 0.75 then
+            return options.slice(options.count / 2, (options.count / 4 * 3) - 1)
+        end
+
+        return options.slice(options.count / 4 * 3, options.count)
+    end
+
+    def hour_slot_to_result(course, year, week, day, slot)
+        # convert to the format required for rendering the page
+        dt = DateTime.commercial(year, week, day, slot[0], (slot[1]-1).to_f/SLOTS_PER_HOUR*60)
+
+        return {"daytext" => daytext(dt), 
+                "date" => dt.to_date.mday.to_s + " " + MONTHS[dt.to_date.mon], 
+                "time" => dt.strftime("%H:%M"),
+                "year" => year,
+                "week" => week,
+                "day" => day,
+                "hour" => slot[0],
+                "slot" => slot[1],
+                "dt" => dt}
+    end
+
+    def daytext(dt)
+        # return a human-friendly day name
+        if dt.today? then
+            return "Vandaag"
+        end
+
+        if dt.to_date == Date.tomorrow then
+            return "Morgen"
+        end
+
+        return DAYS[dt.to_date.wday]
+    end
+end

--- a/app/views/planner/show.html.erb
+++ b/app/views/planner/show.html.erb
@@ -7,25 +7,29 @@
 </div>
 
 <form>
-    <% for i in 0..1 do %>
     <div class="row justify-content-center">
-        <% for j in 0..2 do %>
-        <div class="col-lg-2">
-            <label class="card-input-label">
-                <input type="radio" name="slot" value="<%= i %>-<%= j %>" class="card-input-element">
-                <div class="card d-flex flex-row bg-light">
-                    <div class="card-body">
-                        <small class="text-uppercase text-muted">Vandaag</small>
-                        <h5 class="card-title mt-1">27 juli 2021</h5>
-                        <h6 class="card-subtitle text-muted">Om 13:00</h6>
-                        <a href="#" class=""></a>
-                    </div>
+        <% i = 0%>
+        <% @suggestions.each do |suggestion| %>
+            <% if i % 3 == 0 %>
                 </div>
-            </label>
-        </div>
+                <div class="row justify-content-center">
+            <% end %>
+            <div class="col-lg-2">
+                <label class="card-input-label">
+                    <input type="radio" name="slot" value="<%= suggestion["date"] %>" class="card-input-element">
+                    <div class="card d-flex flex-row bg-light">
+                        <div class="card-body">
+                            <small class="text-uppercase text-muted"><%= suggestion["daytext"] %></small>
+                            <h5 class="card-title mt-1"><%= suggestion["date"] %></h5>
+                            <h6 class="card-subtitle text-muted">Om <%= suggestion["time"] %></h6>
+                            <a href="#" class=""></a>
+                        </div>
+                    </div>
+                </label>
+            </div>
+            <% i += 1 %>
         <% end %>
     </div>
-    <% end %>
 
     <div class="row mb-5 justify-content-center" style="margin-top: 2.5rem;">
         <div class="col-lg-6">


### PR DESCRIPTION
Resolves #3

Slots worden als volgt voorgesteld:
- Als er vandaag nog slots zijn, 4 opties vandaag en 2 opties op de eerst volgende dag met slots;
- Als er vandaag geen slots meer zijn, enkel 4 opties op de eerst volgende dag met slots (er worden dus nooit slots getoond verder dan de eerstvolgende werkdag);
- Bij 2 slots of minder op een dag worden willekeurige slots gekozen met minstens 1,5 uur ertussen;
- Bij meer dan 2 slots wordt altijd het eerst beschikbare slot getoond, de rest wordt ongeveer gelijk verdeeld met een kleine bias naar slots die dichter bij "nu" liggen;